### PR TITLE
Override golang.org/x/net@v0.56.0 and golang.org/x/text@v0.39.0 to fix CVEs

### DIFF
--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,6 +1,9 @@
-# golang.org/x/net: CVE-2026-33814 (net/http2 DoS), CVE-2026-39821 (x/net/idna punycode).
-# Drop once upstream requires golang.org/x/net >= v0.55.0.
--replace golang.org/x/net=golang.org/x/net@v0.55.0
+# golang.org/x/net: CVE-2026-33814 (net/http2 DoS), CVE-2026-39821 (x/net/idna punycode), CVE-2026-46600 (x/net/dns/dnsmessage panic parsing invalid SVCB or HTTPS RR).
+# Drop once upstream requires golang.org/x/net >= v0.56.0.
+-replace golang.org/x/net=golang.org/x/net@v0.56.0
 # golang.org/x/oauth2: CVE-2025-22868 (golang.org/x/oauth2/jws unexpected memory consumption during token parsing).
 # Drop once upstream requires golang.org/x/oauth2 >= v0.27.0.
 -replace golang.org/x/oauth2=golang.org/x/oauth2@v0.27.0
+# golang.org/x/text: CVE-2026-56852 (infinite loop on invalid input).
+# Drop once upstream requires golang.org/x/text >= v0.39.0.
+-replace golang.org/x/text=golang.org/x/text@v0.39.0


### PR DESCRIPTION
## What this does

Adds/updates `go-mod-overrides` to resolve two vulnerabilities reported by Trivy against `rancher/hardened-cluster-autoscaler:v1.10.3-build20260709`:

| Library | Vulnerability | Installed | Fixed |
| --- | --- | --- | --- |
| `golang.org/x/net` | CVE-2026-46600 — parsing an invalid SVCB or HTTPS RR can panic in `golang.org/x/net/dns/dnsmessage` | v0.55.0 | v0.56.0 |
| `golang.org/x/text` | CVE-2026-56852 — infinite loop on invalid input in `golang.org/x/text` | v0.37.0 | v0.39.0 |

### Changes
- Bump the existing `golang.org/x/net` override from `v0.55.0` to `v0.56.0` (and note CVE-2026-46600 in the comment).
- Add a new `golang.org/x/text` override at `v0.39.0`.

These overrides can be dropped once upstream requires `golang.org/x/net >= v0.56.0` and `golang.org/x/text >= v0.39.0`.

Follows the same approach as rancher/image-build-dns-nodecache#188.